### PR TITLE
Ammended ubuntu image sha256 hash

### DIFF
--- a/wistar-vmware.json
+++ b/wistar-vmware.json
@@ -45,7 +45,7 @@
         "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso"
       ],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535",
+      "iso_checksum": "a06cd926f5855d4f21fb4bc9978a35312f815fbda0d0ef7fdc846861f4fc4600",
       "output_directory": "output_images",
       "shutdown_command": "echo '{{ user `ssh_password` }}' | sudo -S shutdown -P now",
       "ssh_password": "{{ user `ssh_password` }}",


### PR DESCRIPTION
Hashes have been updated on the image, thus build fails with incorrect hash. 
http://releases.ubuntu.com/16.04.3/SHA256SUMS